### PR TITLE
Add npm start alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "./node_modules/.bin/component-playground"
+    "start": "component-playground"
   },
   "dependencies": {
     "react": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "start": "./node_modules/.bin/component-playground"
+  },
   "dependencies": {
     "react": "^0.13.1"
   },


### PR DESCRIPTION
It's fairly common for examples to have `npm start` command so people don't have to copy-paste from README.
